### PR TITLE
Add MACE MCP Server for chemistry calculations and usage with OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ Agentic workflows are intelligent computational pipelines that use AI agents to 
 - Natural-language driven PBS interaction
 - Natural-launguage driven job submission, monitoring and job output summary
 
+### 4. [MACE MCP Server for Molecular Simulations](./mace-mcp-server/)
+
+**Description**: An MCP server that exposes MACE machine-learning interatomic potential calculations as tools. Any MCP-compatible client (OpenCode, Claude Code, etc.) can connect and run molecular energy calculations -- molecule name lookup via PubChem, 3D coordinate generation via RDKit, and energy computation / geometry optimisation via the MACE-MP foundation model -- without writing chemistry code. By pairing an MCP server with OpenCode, the orchestration layer (LLM client, tool discovery, and tool calling) is provided out of the box, so development effort focuses entirely on the scientific tools themselves.
+
+**Technologies**:
+- **Model Context Protocol (MCP)** - FastMCP server exposing MACE tools via stdio
+- **MACE-MP** - Machine-learning interatomic potential (foundation model for molecules and materials)
+- **RDKit** - 3D molecular coordinate generation
+- **PubChemPy** - Molecule name to SMILES resolution via PubChem
+- **ASE** - Atomic Simulation Environment for structure I/O and optimisation
+- **OpenCode** - MCP-compatible AI coding agent with ALCF inference endpoint support
+
+**Use Cases**:
+- AI-assisted molecular energy calculations
+- LLM-driven molecular structure exploration
+- Rapid prototyping of computational chemistry workflows
+- Protocol-agnostic tool serving for scientific computing
+
 ---
 
 ## 🚀 Getting Started

--- a/mace-mcp-server/README.md
+++ b/mace-mcp-server/README.md
@@ -39,16 +39,6 @@ Install via the install script:
 curl -fsSL https://opencode.ai/install | bash
 ```
 
-Or use one of the alternative methods:
-
-```bash
-# npm
-npm install -g opencode-ai
-
-# Homebrew (macOS / Linux)
-brew install anomalyco/tap/opencode
-```
-
 See the [OpenCode docs](https://opencode.ai/docs/) for the full list of installation options.
 
 ---
@@ -56,14 +46,18 @@ See the [OpenCode docs](https://opencode.ai/docs/) for the full list of installa
 ## 2. Set Up the MCP Server
 
 ```bash
-# 1. Navigate to the server directory
+# 1. Clone the repository
+git clone https://github.com/argonne-lcf/alcf-agentics-workflow.git
+cd alcf-agentics-workflow
+
+# 2. Navigate to the server directory
 cd mace-mcp-server
 
-# 2. Create and activate a virtual environment
+# 3. Create and activate a virtual environment
 python -m venv .venv
 source .venv/bin/activate            # On Windows: .venv\Scripts\activate
 
-# 3. Install dependencies
+# 4. Install dependencies
 pip install -r requirements.txt
 ```
 
@@ -71,20 +65,25 @@ On ALCF systems (Polaris, Sophia, etc.), load the frameworks module first:
 
 ```bash
 module load frameworks
+
+# Compute nodes require a proxy for internet access
+export http_proxy="http://proxy.alcf.anl.gov:3128"
+export https_proxy="http://proxy.alcf.anl.gov:3128"
+
 python3 -m venv .venv --system-site-packages
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+> **Note:** The proxy exports are also needed at runtime on compute nodes for PubChem lookups and the first-time MACE model download.
+
 ### Verify the installation
 
 ```bash
-python -c "from mcp.server.fastmcp import FastMCP; print('MCP SDK: OK')"
-python -c "import pubchempy; print('PubChemPy: OK')"
-python -c "from rdkit import Chem; print('RDKit: OK')"
-python -c "import ase; print('ASE: OK')"
-python -c "from mace.calculators import mace_mp; print('MACE: OK')"
+python tests/check_env.py
 ```
+
+This runs through all required imports (MCP SDK, PubChemPy, RDKit, ASE, MACE) and prints a pass/fail summary. If anything is missing, it shows the install command to fix it.
 
 ---
 
@@ -96,18 +95,36 @@ Full details: [ALCF Inference Endpoints documentation](https://docs.alcf.anl.gov
 
 ### 3a. Get an ALCF access token
 
+> **Note:** This step is the equivalent of `python src/tools/globus_interface.py authenticate` in the other examples (pbsMCP, remoteGlobusToAurora). The mace-mcp-server uses a different auth script because it only needs inference endpoint access, not Globus Compute or Transfer.
+
+A convenience script wraps the download, authentication, and token export. Use `--persist` to save the token to your shell profile (`~/.zshrc` or `~/.bashrc`, auto-detected) so it is available in future sessions:
+
+```bash
+source scripts/setup_auth.sh --persist
+```
+
+To re-authenticate (e.g. after the 30-day session expiry):
+
+```bash
+source scripts/setup_auth.sh --force --persist
+```
+
+Or run the steps manually:
+
 ```bash
 # Download the authentication helper script
-wget https://raw.githubusercontent.com/argonne-lcf/inference-endpoints/refs/heads/main/inference_auth_token.py
+curl -fsSL https://raw.githubusercontent.com/argonne-lcf/inference-endpoints/refs/heads/main/inference_auth_token.py -o inference_auth_token.py
 
 # Authenticate with your Globus/ALCF account (opens a browser)
 python inference_auth_token.py authenticate
 
-# Export the token as an environment variable
-export ALCF_INFERENCE_TOKEN=$(python inference_auth_token.py get_access_token)
+# Get the token value
+python inference_auth_token.py get_access_token
 ```
 
-> **Note:** Access tokens are valid for **48 hours**. The `get_access_token` command automatically refreshes expired tokens. Re-authentication is required every 30 days. If you encounter permission errors, log out at [app.globus.org/logout](https://app.globus.org/logout) and re-run `authenticate --force`.
+After obtaining your token (via the script or manually), **copy the token value into the `apiKey` fields** in `~/.config/opencode/opencode.json` (see step 3b below). Replace `YOUR_ALCF_TOKEN_HERE` with the actual token.
+
+> **Note:** Access tokens are valid for **48 hours**. Run `python inference_auth_token.py get_access_token` to refresh an expired token and update the `apiKey` value in your config. Re-authentication is required every 30 days. If you encounter permission errors, log out at [app.globus.org/logout](https://app.globus.org/logout) and re-run `source scripts/setup_auth.sh --force --persist`.
 
 ### 3b. Add ALCF providers to your global OpenCode config
 
@@ -128,7 +145,7 @@ Create or edit `~/.config/opencode/opencode.json`:
       "name": "Sophia",
       "options": {
         "baseURL": "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1",
-        "apiKey": "{env:ALCF_INFERENCE_TOKEN}"
+        "apiKey": "YOUR_ALCF_TOKEN_HERE"
       },
       "models": {
         "openai/gpt-oss-120b": {
@@ -144,7 +161,7 @@ Create or edit `~/.config/opencode/opencode.json`:
       "name": "Metis",
       "options": {
         "baseURL": "https://inference-api.alcf.anl.gov/resource_server/metis/api/v1",
-        "apiKey": "{env:ALCF_INFERENCE_TOKEN}"
+        "apiKey": "YOUR_ALCF_TOKEN_HERE"
       },
       "models": {
         "gpt-oss-120b": {
@@ -160,7 +177,7 @@ Create or edit `~/.config/opencode/opencode.json`:
 
 **Key points:**
 
-- **`{env:ALCF_INFERENCE_TOKEN}`** reads the token from your environment variable (set in step 3a).
+- **`apiKey`** must be set to your actual ALCF access token (obtained in step 3a). Replace `YOUR_ALCF_TOKEN_HERE` with the token value. When the token expires (every 48 hours), update this field with a fresh token.
 - **Two clusters are available:**
 
   | Cluster | Framework | Supported Endpoints | Notes |
@@ -269,17 +286,22 @@ Some complex SMILES strings may fail RDKit's distance-geometry embedding. Try:
 
 ### ALCF token expired
 
-Access tokens expire after 48 hours. Re-export:
+Access tokens expire after 48 hours. Get a fresh token and update your config:
 
 ```bash
-export ALCF_INFERENCE_TOKEN=$(python inference_auth_token.py get_access_token)
+# Get a new token
+python inference_auth_token.py get_access_token
 ```
+
+Copy the output and paste it into the `apiKey` fields in `~/.config/opencode/opencode.json`.
 
 If you get permission errors after 30 days, re-authenticate:
 
 ```bash
-python inference_auth_token.py authenticate --force
+source scripts/setup_auth.sh --force --persist
 ```
+
+Then update the `apiKey` in your OpenCode config with the new token.
 
 ---
 

--- a/mace-mcp-server/README.md
+++ b/mace-mcp-server/README.md
@@ -1,0 +1,290 @@
+# MACE MCP Server
+
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that exposes [MACE](https://github.com/ACEsuit/mace) machine-learning interatomic potential calculations as tools. Connect any MCP-compatible AI client to run molecular energy calculations without writing chemistry code.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [1. Install OpenCode](#1-install-opencode)
+- [2. Set Up the MCP Server](#2-set-up-the-mcp-server)
+- [3. Configure ALCF Inference Endpoints](#3-configure-alcf-inference-endpoints)
+  - [3a. Get an ALCF access token](#3a-get-an-alcf-access-token)
+  - [3b. Add ALCF providers to your global OpenCode config](#3b-add-alcf-providers-to-your-global-opencode-config)
+  - [3c. Project opencode.json (MCP server config)](#3c-project-opencodejson-mcp-server-config)
+- [4. Running](#4-running)
+- [Troubleshooting](#troubleshooting)
+- [Learn More](#learn-more)
+
+---
+
+## Prerequisites
+
+- **Python 3.10+**
+- **An ALCF account** with access to [inference endpoints](https://docs.alcf.anl.gov/services/inference-endpoints/)
+- **Internet access** (for PubChem lookups and first-time MACE model download)
+
+No GPU is required -- the MACE-MP "small" model runs on CPU.
+
+---
+
+## 1. Install OpenCode
+
+[OpenCode](https://opencode.ai/) is an open-source AI coding agent that supports MCP servers and can use ALCF inference endpoints as its LLM backend.
+
+Install via the install script:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+Or use one of the alternative methods:
+
+```bash
+# npm
+npm install -g opencode-ai
+
+# Homebrew (macOS / Linux)
+brew install anomalyco/tap/opencode
+```
+
+See the [OpenCode docs](https://opencode.ai/docs/) for the full list of installation options.
+
+---
+
+## 2. Set Up the MCP Server
+
+```bash
+# 1. Navigate to the server directory
+cd mace-mcp-server
+
+# 2. Create and activate a virtual environment
+python -m venv .venv
+source .venv/bin/activate            # On Windows: .venv\Scripts\activate
+
+# 3. Install dependencies
+pip install -r requirements.txt
+```
+
+On ALCF systems (Polaris, Sophia, etc.), load the frameworks module first:
+
+```bash
+module load frameworks
+python3 -m venv .venv --system-site-packages
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Verify the installation
+
+```bash
+python -c "from mcp.server.fastmcp import FastMCP; print('MCP SDK: OK')"
+python -c "import pubchempy; print('PubChemPy: OK')"
+python -c "from rdkit import Chem; print('RDKit: OK')"
+python -c "import ase; print('ASE: OK')"
+python -c "from mace.calculators import mace_mp; print('MACE: OK')"
+```
+
+---
+
+## 3. Configure ALCF Inference Endpoints
+
+ALCF provides free inference access to open-source LLMs running on dedicated hardware (Sophia and Metis clusters). These endpoints are OpenAI-compatible, so OpenCode can use them as a custom provider.
+
+Full details: [ALCF Inference Endpoints documentation](https://docs.alcf.anl.gov/services/inference-endpoints/)
+
+### 3a. Get an ALCF access token
+
+```bash
+# Download the authentication helper script
+wget https://raw.githubusercontent.com/argonne-lcf/inference-endpoints/refs/heads/main/inference_auth_token.py
+
+# Authenticate with your Globus/ALCF account (opens a browser)
+python inference_auth_token.py authenticate
+
+# Export the token as an environment variable
+export ALCF_INFERENCE_TOKEN=$(python inference_auth_token.py get_access_token)
+```
+
+> **Note:** Access tokens are valid for **48 hours**. The `get_access_token` command automatically refreshes expired tokens. Re-authentication is required every 30 days. If you encounter permission errors, log out at [app.globus.org/logout](https://app.globus.org/logout) and re-run `authenticate --force`.
+
+### 3b. Add ALCF providers to your global OpenCode config
+
+OpenCode reads provider configuration from `~/.config/opencode/opencode.json` (global, applies to all projects). Add the ALCF providers there:
+
+```bash
+mkdir -p ~/.config/opencode
+```
+
+Create or edit `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "alcf_sophia": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Sophia",
+      "options": {
+        "baseURL": "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1",
+        "apiKey": "{env:ALCF_INFERENCE_TOKEN}"
+      },
+      "models": {
+        "openai/gpt-oss-120b": {
+          "name": "gpt-oss-120b"
+        },
+        "openai/gpt-oss-20b": {
+          "name": "gpt-oss-20b"
+        }
+      }
+    },
+    "alcf_metis": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Metis",
+      "options": {
+        "baseURL": "https://inference-api.alcf.anl.gov/resource_server/metis/api/v1",
+        "apiKey": "{env:ALCF_INFERENCE_TOKEN}"
+      },
+      "models": {
+        "gpt-oss-120b": {
+          "name": "gpt-oss-120b"
+        }
+      }
+    }
+  }
+}
+```
+
+> **Tip:** A copy of this config is available at [`config/opencode.json`](config/opencode.json) for reference.
+
+**Key points:**
+
+- **`{env:ALCF_INFERENCE_TOKEN}`** reads the token from your environment variable (set in step 3a).
+- **Two clusters are available:**
+
+  | Cluster | Framework | Supported Endpoints | Notes |
+  |---------|-----------|-------------------|-------|
+  | **Sophia** | vLLM | Chat, completions, embeddings, batch | Broader model selection, tool calling support |
+  | **Metis** | SambaNova | Chat completions only | Fewer models, no batch or tool calling |
+
+- See the [ALCF Inference Endpoints docs](https://docs.alcf.anl.gov/services/inference-endpoints/#available-models) for the full list of available models.
+
+### 3c. Project `opencode.json` (MCP server config)
+
+The project already includes an `opencode.json` at the repository root that configures the MACE MCP server:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "chemistry": {
+      "type": "local",
+      "command": [".venv/bin/python", "src/server.py"],
+      "enabled": true
+    }
+  }
+}
+```
+
+This uses the `.venv` Python interpreter created in step 2. OpenCode merges this project config with your global config, so the ALCF providers and the MCP server are both available when you run `opencode` from this directory.
+
+---
+
+## 4. Running
+
+### Option 1: Via OpenCode (recommended)
+
+With `opencode.json` configured, simply run OpenCode from the project directory:
+
+```bash
+opencode
+```
+
+OpenCode will automatically:
+- Connect to the ALCF inference endpoint as the LLM backend
+- Launch the MACE MCP server as a subprocess
+- Make the chemistry tools available to the LLM
+
+You can then ask questions like:
+- "What is the energy of a water molecule?"
+- "Optimise the geometry of ethanol using MACE"
+- "Compare the energies of methane and ethane"
+
+Use `/models` in the OpenCode TUI to switch between available ALCF models.
+
+### Option 2: Example Client (no LLM required)
+
+Run the demo client that exercises all three tools end-to-end:
+
+```bash
+python src/example_client.py
+```
+
+This connects to the MCP server over stdio and runs demos for ethanol, aspirin, and water.
+
+---
+
+## Troubleshooting
+
+### "pubchempy is not installed"
+
+```bash
+pip install pubchempy
+```
+
+### "RDKit is not installed"
+
+```bash
+pip install rdkit-pypi
+```
+
+If that fails on your platform, try installing via conda:
+```bash
+conda install -c conda-forge rdkit
+```
+
+### "MACE is not installed"
+
+```bash
+pip install mace-torch
+```
+
+MACE requires PyTorch. If you don't have it:
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cpu  # CPU only
+pip install mace-torch
+```
+
+### First run is slow
+
+On the first call to `run_mace_calculation`, the MACE-MP model weights are downloaded (~100 MB for "small"). Subsequent runs use the cached model.
+
+### "Failed to generate 3D coordinates"
+
+Some complex SMILES strings may fail RDKit's distance-geometry embedding. Try:
+- Simplifying the molecule
+- Using a different `random_seed`
+- Providing your own XYZ file directly to `run_mace_calculation`
+
+### ALCF token expired
+
+Access tokens expire after 48 hours. Re-export:
+
+```bash
+export ALCF_INFERENCE_TOKEN=$(python inference_auth_token.py get_access_token)
+```
+
+If you get permission errors after 30 days, re-authenticate:
+
+```bash
+python inference_auth_token.py authenticate --force
+```
+
+---
+
+## Learn More
+
+- **[ALCF Inference Endpoints](https://docs.alcf.anl.gov/services/inference-endpoints/)** -- Full documentation for ALCF's inference service, available models, and API usage
+- **[OpenCode documentation](https://opencode.ai/docs/)** -- Installation, configuration, providers, and MCP server setup
+- **[OpenCode providers](https://opencode.ai/docs/providers/)** -- How to configure custom OpenAI-compatible providers (like ALCF)

--- a/mace-mcp-server/README.md
+++ b/mace-mcp-server/README.md
@@ -2,6 +2,8 @@
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that exposes [MACE](https://github.com/ACEsuit/mace) machine-learning interatomic potential calculations as tools. Connect any MCP-compatible AI client to run molecular energy calculations without writing chemistry code.
 
+By pairing an MCP server with [OpenCode](https://opencode.ai/), the orchestration layer (LLM client, tool discovery, and tool calling) is provided out of the box. This means you can focus entirely on writing the scientific tools themselves, rather than building a custom agent loop or orchestration framework.
+
 ---
 
 ## Table of Contents
@@ -26,6 +28,14 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that e
 - **Internet access** (for PubChem lookups and first-time MACE model download)
 
 No GPU is required -- the MACE-MP "small" model runs on CPU.
+
+### Where to run
+
+This example can be run on either a **local system** (laptop or workstation) or an **ALCF compute node** (Aurora, Polaris, etc.):
+
+- **Local system** -- The simplest option. MACE-MP "small" runs on CPU, so no special hardware is needed. Your machine has direct internet access for PubChem lookups and the first-time MACE model download (~100 MB). Install OpenCode and the Python dependencies as described below, then run `opencode` from the project directory.
+
+- **ALCF compute node** -- Also supported. Follow the ALCF-specific setup in [Step 2](#2-set-up-the-mcp-server) to load the `frameworks` module and set the HTTP proxy environment variables. The proxy is required at both install time and runtime so that PubChem lookups and the initial MACE model download can reach the internet.
 
 ---
 
@@ -103,12 +113,6 @@ A convenience script wraps the download, authentication, and token export. Use `
 source scripts/setup_auth.sh --persist
 ```
 
-To re-authenticate (e.g. after the 30-day session expiry):
-
-```bash
-source scripts/setup_auth.sh --force --persist
-```
-
 Or run the steps manually:
 
 ```bash
@@ -123,8 +127,6 @@ python inference_auth_token.py get_access_token
 ```
 
 After obtaining your token (via the script or manually), **copy the token value into the `apiKey` fields** in `~/.config/opencode/opencode.json` (see step 3b below). Replace `YOUR_ALCF_TOKEN_HERE` with the actual token.
-
-> **Note:** Access tokens are valid for **48 hours**. Run `python inference_auth_token.py get_access_token` to refresh an expired token and update the `apiKey` value in your config. Re-authentication is required every 30 days. If you encounter permission errors, log out at [app.globus.org/logout](https://app.globus.org/logout) and re-run `source scripts/setup_auth.sh --force --persist`.
 
 ### 3b. Add ALCF providers to your global OpenCode config
 
@@ -178,13 +180,6 @@ Create or edit `~/.config/opencode/opencode.json`:
 **Key points:**
 
 - **`apiKey`** must be set to your actual ALCF access token (obtained in step 3a). Replace `YOUR_ALCF_TOKEN_HERE` with the token value. When the token expires (every 48 hours), update this field with a fresh token.
-- **Two clusters are available:**
-
-  | Cluster | Framework | Supported Endpoints | Notes |
-  |---------|-----------|-------------------|-------|
-  | **Sophia** | vLLM | Chat, completions, embeddings, batch | Broader model selection, tool calling support |
-  | **Metis** | SambaNova | Chat completions only | Fewer models, no batch or tool calling |
-
 - See the [ALCF Inference Endpoints docs](https://docs.alcf.anl.gov/services/inference-endpoints/#available-models) for the full list of available models.
 
 ### 3c. Project `opencode.json` (MCP server config)

--- a/mace-mcp-server/config/opencode.json
+++ b/mace-mcp-server/config/opencode.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "alcf_sophia": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Sophia",
+      "options": {
+        "baseURL": "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1",
+        "apiKey": "{env:ALCF_INFERENCE_TOKEN}"
+      },
+      "models": {
+        "openai/gpt-oss-120b": {
+          "name": "gpt-oss-120b"
+        },
+        "openai/gpt-oss-20b": {
+          "name": "gpt-oss-20b"
+        }
+      }
+    },
+    "alcf_metis": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Metis",
+      "options": {
+        "baseURL": "https://inference-api.alcf.anl.gov/resource_server/metis/api/v1",
+        "apiKey": "{env:ALCF_INFERENCE_TOKEN}"
+      },
+      "models": {
+        "gpt-oss-120b": {
+          "name": "gpt-oss-120b"
+        }
+      }
+    }
+  }
+}

--- a/mace-mcp-server/opencode.json
+++ b/mace-mcp-server/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "chemistry": {
+      "type": "local",
+      "command": [".venv/bin/python", "src/server.py"],
+      "enabled": true
+    }
+  }
+}

--- a/mace-mcp-server/requirements.txt
+++ b/mace-mcp-server/requirements.txt
@@ -1,0 +1,16 @@
+# MCP server framework
+mcp>=1.0.0
+
+# Chemistry / molecular tools
+pubchempy>=1.0.4
+rdkit
+ase>=3.22.0
+numpy>=1.20.0
+
+# MACE machine-learning interatomic potential
+mace-torch==0.3.15
+
+# Development / testing
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+ruff>=0.1.0

--- a/mace-mcp-server/scripts/setup_auth.sh
+++ b/mace-mcp-server/scripts/setup_auth.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# -------------------------------------------------------------------
+# ALCF Inference Endpoint Authentication
+#
+# Downloads the ALCF authentication helper (if not already present),
+# runs Globus-based authentication, and exports the access token.
+#
+# Usage (run from the mace-mcp-server directory):
+#
+#   # Authenticate and set the token for this shell session
+#   source scripts/setup_auth.sh
+#
+#   # Authenticate and persist the token in your shell profile
+#   # (~/.zshrc or ~/.bashrc, auto-detected)
+#   source scripts/setup_auth.sh --persist
+#
+#   # Force re-authentication (e.g. after 30-day expiry)
+#   source scripts/setup_auth.sh --force
+#
+#   # Combine flags
+#   source scripts/setup_auth.sh --force --persist
+# -------------------------------------------------------------------
+
+set -euo pipefail
+
+AUTH_SCRIPT="inference_auth_token.py"
+AUTH_URL="https://raw.githubusercontent.com/argonne-lcf/inference-endpoints/refs/heads/main/${AUTH_SCRIPT}"
+
+# ----- Parse flags -----
+
+FORCE=""
+PERSIST=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --force)  FORCE="--force" ;;
+        --persist) PERSIST=true ;;
+        *)
+            echo "Unknown option: $arg"
+            echo "Usage: source scripts/setup_auth.sh [--force] [--persist]"
+            return 1 2>/dev/null || exit 1
+            ;;
+    esac
+done
+
+# ----- Helper: mask a token for safe display -----
+
+mask_token() {
+    local token="$1"
+    local last4="${token: -4}"
+    echo "****${last4}"
+}
+
+# ----- Step 1: Download the auth helper if missing -----
+
+if [[ ! -f "$AUTH_SCRIPT" ]]; then
+    echo "Downloading ${AUTH_SCRIPT} ..."
+    curl -fsSL "$AUTH_URL" -o "$AUTH_SCRIPT"
+    echo "  saved to ./${AUTH_SCRIPT}"
+else
+    echo "Auth helper already present: ./${AUTH_SCRIPT}"
+fi
+
+# ----- Step 2: Authenticate with Globus / ALCF -----
+
+echo ""
+echo "Authenticating with ALCF (this may open a browser window) ..."
+python "$AUTH_SCRIPT" authenticate $FORCE
+
+# ----- Step 3: Obtain and export the access token -----
+
+TOKEN=$(python "$AUTH_SCRIPT" get_access_token)
+
+if [[ -z "$TOKEN" ]]; then
+    echo ""
+    echo "ERROR: Failed to obtain an access token."
+    echo "Try re-running with --force:  source scripts/setup_auth.sh --force"
+    return 1 2>/dev/null || exit 1
+fi
+
+export ALCF_INFERENCE_TOKEN="$TOKEN"
+
+MASKED=$(mask_token "$TOKEN")
+echo ""
+echo "ALCF_INFERENCE_TOKEN has been set (${MASKED})."
+
+# ----- Step 4 (optional): Persist to shell RC file -----
+
+if $PERSIST; then
+    # Auto-detect RC file based on current shell
+    if [[ "$SHELL" == *zsh* ]]; then
+        RC_FILE="$HOME/.zshrc"
+    else
+        RC_FILE="$HOME/.bashrc"
+    fi
+
+    EXPORT_LINE="export ALCF_INFERENCE_TOKEN=\"${TOKEN}\""
+
+    if [[ -f "$RC_FILE" ]] && grep -q "^export ALCF_INFERENCE_TOKEN=" "$RC_FILE"; then
+        # Replace existing line
+        # Use a delimiter that won't clash with the token value
+        sed -i.bak "s|^export ALCF_INFERENCE_TOKEN=.*|${EXPORT_LINE}|" "$RC_FILE"
+        rm -f "${RC_FILE}.bak"
+        echo "Updated existing token in ${RC_FILE} (${MASKED})."
+    else
+        # Append
+        echo "" >> "$RC_FILE"
+        echo "# ALCF Inference Endpoint token (added by scripts/setup_auth.sh)" >> "$RC_FILE"
+        echo "$EXPORT_LINE" >> "$RC_FILE"
+        echo "Token saved to ${RC_FILE} (${MASKED}). It will be available in new shell sessions."
+    fi
+fi
+
+# ----- Warn if not sourced -----
+
+# shellcheck disable=SC2128
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]] 2>/dev/null; then
+    echo ""
+    echo "NOTE: You ran this script directly, so the token is only set in"
+    echo "this subshell.  To set it in your current shell, run:"
+    echo ""
+    echo "  source scripts/setup_auth.sh --persist"
+fi

--- a/mace-mcp-server/src/example_client.py
+++ b/mace-mcp-server/src/example_client.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Example MCP client for the MACE MCP Server.
+
+Demonstrates the complete end-to-end workflow: **molecule name -> SMILES ->
+3D coordinates -> MACE energy calculation**.
+
+No LLM is involved -- this script calls MCP tools directly to verify
+the server works end-to-end.
+
+Workflow
+--------
+1. Connect to the MACE MCP server over stdio.
+2. Discover available tools.
+3. Demo 1: Look up "ethanol" -> generate XYZ -> MACE single-point energy.
+4. Demo 2: Look up "aspirin" -> generate XYZ -> MACE geometry optimisation.
+5. Demo 3: Direct SMILES input ("O" for water) -> XYZ -> MACE energy.
+
+Usage
+-----
+    python src/example_client.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+# Path to the server script (same directory)
+SERVER_SCRIPT = str(Path(__file__).resolve().parent / "server.py")
+
+
+def _pretty(data: Any, label: str) -> None:
+    """Print a labelled JSON result."""
+    print(f"\n{'=' * 70}")
+    print(f"  {label}")
+    print(f"{'=' * 70}")
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    print(json.dumps(data, indent=2) if isinstance(data, (dict, list)) else data)
+
+
+async def call_tool(
+    session: ClientSession,
+    name: str,
+    arguments: Dict[str, Any] | None = None,
+) -> Any:
+    """Call an MCP tool and return the parsed result."""
+    result = await session.call_tool(name, arguments or {})
+
+    # Extract text content from the MCP result
+    text_parts = []
+    for block in result.content or []:
+        if hasattr(block, "text"):
+            text_parts.append(block.text)
+    combined = "\n".join(text_parts) if text_parts else str(result)
+
+    try:
+        return json.loads(combined)
+    except (json.JSONDecodeError, TypeError):
+        return combined
+
+
+async def run_demo() -> None:
+    """Connect to the MACE MCP server and run example calculations."""
+    print("MACE MCP Server - Example Client")
+    print("=" * 70)
+    print("End-to-end demo: molecule name -> SMILES -> 3D structure -> energy")
+    print("=" * 70)
+
+    # Launch the server as a subprocess
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=[SERVER_SCRIPT],
+        env={**os.environ},
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+
+            # ---- 1. Discover tools ----
+            tools_result = await session.list_tools()
+            tool_names = [t.name for t in tools_result.tools]
+            print(f"\nDiscovered {len(tool_names)} tools:")
+            for name in sorted(tool_names):
+                print(f"  - {name}")
+
+            # ================================================================
+            # Demo 1: Ethanol -- full pipeline (single-point energy)
+            # ================================================================
+
+            print(f"\n{'#' * 70}")
+            print("  DEMO 1: Ethanol -- Name -> SMILES -> XYZ -> Energy")
+            print(f"{'#' * 70}")
+
+            # Step 1a: Look up SMILES for ethanol
+            smiles_result = await call_tool(
+                session,
+                "molecule_name_to_smiles",
+                {"name": "ethanol"},
+            )
+            _pretty(smiles_result, "Step 1: molecule_name_to_smiles('ethanol')")
+
+            if smiles_result.get("status") != "completed":
+                print("ERROR: Could not resolve ethanol. Skipping demo 1.")
+            else:
+                ethanol_smiles = smiles_result["smiles"]
+
+                # Step 1b: Generate XYZ file
+                xyz_result = await call_tool(
+                    session,
+                    "smiles_to_coordinate_file",
+                    {
+                        "smiles": ethanol_smiles,
+                        "output_file": "ethanol.xyz",
+                    },
+                )
+                _pretty(
+                    xyz_result,
+                    f"Step 2: smiles_to_coordinate_file('{ethanol_smiles}')",
+                )
+
+                if xyz_result.get("status") == "completed":
+                    # Step 1c: Run MACE single-point energy
+                    mace_result = await call_tool(
+                        session,
+                        "run_mace_calculation",
+                        {
+                            "input_file": xyz_result["path"],
+                            "mace_model_name": "small",
+                            "device": "cpu",
+                        },
+                    )
+                    _pretty(
+                        mace_result,
+                        "Step 3: run_mace_calculation (single-point)",
+                    )
+
+            # ================================================================
+            # Demo 2: Aspirin -- full pipeline (geometry optimisation)
+            # ================================================================
+
+            print(f"\n{'#' * 70}")
+            print("  DEMO 2: Aspirin -- Name -> SMILES -> XYZ -> Optimise")
+            print(f"{'#' * 70}")
+
+            smiles_result = await call_tool(
+                session,
+                "molecule_name_to_smiles",
+                {"name": "aspirin"},
+            )
+            _pretty(smiles_result, "Step 1: molecule_name_to_smiles('aspirin')")
+
+            if smiles_result.get("status") != "completed":
+                print("ERROR: Could not resolve aspirin. Skipping demo 2.")
+            else:
+                aspirin_smiles = smiles_result["smiles"]
+
+                xyz_result = await call_tool(
+                    session,
+                    "smiles_to_coordinate_file",
+                    {
+                        "smiles": aspirin_smiles,
+                        "output_file": "aspirin.xyz",
+                    },
+                )
+                _pretty(
+                    xyz_result,
+                    f"Step 2: smiles_to_coordinate_file('{aspirin_smiles}')",
+                )
+
+                if xyz_result.get("status") == "completed":
+                    mace_result = await call_tool(
+                        session,
+                        "run_mace_calculation",
+                        {
+                            "input_file": xyz_result["path"],
+                            "mace_model_name": "small",
+                            "device": "cpu",
+                            "optimize": True,
+                            "fmax": 0.05,
+                            "max_steps": 100,
+                        },
+                    )
+                    _pretty(
+                        mace_result,
+                        "Step 3: run_mace_calculation (geometry optimisation)",
+                    )
+
+            # ================================================================
+            # Demo 3: Water -- direct SMILES input (no name lookup)
+            # ================================================================
+
+            print(f"\n{'#' * 70}")
+            print("  DEMO 3: Water -- Direct SMILES -> XYZ -> Energy")
+            print(f"{'#' * 70}")
+
+            xyz_result = await call_tool(
+                session,
+                "smiles_to_coordinate_file",
+                {
+                    "smiles": "O",
+                    "output_file": "water.xyz",
+                },
+            )
+            _pretty(xyz_result, "Step 1: smiles_to_coordinate_file('O')")
+
+            if xyz_result.get("status") == "completed":
+                mace_result = await call_tool(
+                    session,
+                    "run_mace_calculation",
+                    {
+                        "input_file": xyz_result["path"],
+                        "mace_model_name": "small",
+                        "device": "cpu",
+                    },
+                )
+                _pretty(mace_result, "Step 2: run_mace_calculation (single-point)")
+
+    print(f"\n{'=' * 70}")
+    print("  All demos completed!")
+    print(f"{'=' * 70}\n")
+
+
+def main() -> None:
+    asyncio.run(run_demo())
+
+
+if __name__ == "__main__":
+    main()

--- a/mace-mcp-server/src/server.py
+++ b/mace-mcp-server/src/server.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+MACE MCP Server
+===============
+
+A Model Context Protocol (MCP) server that exposes MACE machine-learning
+interatomic potential calculations as tools.  Any MCP-compatible client
+(Claude Desktop, an OpenAI tool-calling agent, the MCP Inspector, etc.)
+can connect and run molecular simulations without writing chemistry code.
+
+The server wraps the three tools from the ALCF AI Science Training Series
+(``tools.py``):
+
+- ``molecule_name_to_smiles``   -- resolve a molecule name to SMILES via PubChem
+- ``smiles_to_coordinate_file`` -- generate 3D coordinates from SMILES (RDKit + ASE)
+- ``run_mace_calculation``      -- compute energies with the MACE-MP potential
+
+Together they form an end-to-end pipeline:
+**molecule name -> SMILES -> 3D structure -> energy / optimised geometry**.
+
+Usage
+-----
+The server communicates over **stdio** and is designed to be launched as a
+subprocess by an MCP client::
+
+    python src/server.py
+
+It can also be tested interactively with the MCP Inspector::
+
+    npx @modelcontextprotocol/inspector python src/server.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from tools.molecule_lookup import molecule_name_to_smiles as _molecule_name_to_smiles
+from tools.coordinate_gen import smiles_to_coordinate_file as _smiles_to_coordinate_file
+from tools.mace_calc import run_mace_calculation as _run_mace_calculation
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger("mace_mcp.server")
+
+# ---------------------------------------------------------------------------
+# MCP Server
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP("MACE Chemistry Server")
+
+
+# ---- Tool 1: Molecule name -> SMILES --------------------------------------
+
+
+@mcp.tool()
+def molecule_name_to_smiles(name: str) -> str:
+    """Convert a molecule name to its canonical SMILES string via PubChem.
+
+    Use this tool when you have a common or IUPAC molecule name (e.g.
+    "aspirin", "caffeine", "water") and need the SMILES representation
+    for downstream processing.
+
+    Parameters
+    ----------
+    name : str
+        The molecule name to look up (e.g. "aspirin", "ethanol", "benzene").
+    """
+    logger.info("molecule_name_to_smiles: name=%s", name)
+    result = _molecule_name_to_smiles(name)
+    return json.dumps(result, indent=2)
+
+
+# ---- Tool 2: SMILES -> coordinate file ------------------------------------
+
+
+@mcp.tool()
+def smiles_to_coordinate_file(
+    smiles: str,
+    output_file: str = "molecule.xyz",
+    random_seed: int = 2025,
+) -> str:
+    """Convert a SMILES string to a 3D coordinate file (XYZ format).
+
+    Generates a 3D molecular structure from a SMILES string using RDKit's
+    distance-geometry embedding and UFF force-field pre-optimisation.
+    The result is written as an XYZ file via ASE.
+
+    Use this after ``molecule_name_to_smiles`` to create a structure file
+    that can be passed to ``run_mace_calculation``.
+
+    Parameters
+    ----------
+    smiles : str
+        SMILES string (e.g. "CCO" for ethanol, "O" for water).
+    output_file : str
+        Path for the output XYZ file (default "molecule.xyz").
+    random_seed : int
+        Random seed for reproducible 3D embedding (default 2025).
+    """
+    logger.info("smiles_to_coordinate_file: smiles=%s output=%s", smiles, output_file)
+    result = _smiles_to_coordinate_file(
+        smiles=smiles,
+        output_file=output_file,
+        random_seed=random_seed,
+    )
+    return json.dumps(result, indent=2)
+
+
+# ---- Tool 3: MACE calculation ---------------------------------------------
+
+
+@mcp.tool()
+def run_mace_calculation(
+    input_file: str,
+    mace_model_name: str = "small",
+    device: str = "cpu",
+    optimize: bool = False,
+    fmax: float = 0.05,
+    max_steps: int = 200,
+) -> str:
+    """Run a MACE machine-learning potential energy calculation.
+
+    Computes the potential energy of a molecular structure using the
+    MACE-MP foundation model.  Optionally performs a BFGS geometry
+    optimisation to find the energy minimum.
+
+    Use this after ``smiles_to_coordinate_file`` to compute the energy
+    of a generated structure.
+
+    Parameters
+    ----------
+    input_file : str
+        Path to a structure file readable by ASE (typically an XYZ file
+        produced by ``smiles_to_coordinate_file``).
+    mace_model_name : str
+        MACE-MP model variant: "small", "medium", or "large" (default "small").
+    device : str
+        Compute device: "cpu" or "cuda" (default "cpu").
+    optimize : bool
+        If True, run BFGS geometry optimisation (default False).
+    fmax : float
+        Force convergence threshold in eV/A for optimisation (default 0.05).
+    max_steps : int
+        Maximum optimisation steps (default 200).
+    """
+    logger.info(
+        "run_mace_calculation: file=%s model=%s device=%s optimize=%s",
+        input_file,
+        mace_model_name,
+        device,
+        optimize,
+    )
+    result = _run_mace_calculation(
+        input_file=input_file,
+        mace_model_name=mace_model_name,
+        device=device,
+        optimize=optimize,
+        fmax=fmax,
+        max_steps=max_steps,
+    )
+    return json.dumps(result, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    logger.info("Starting MACE MCP Server v0.1.0")
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/mace-mcp-server/src/tools/__init__.py
+++ b/mace-mcp-server/src/tools/__init__.py
@@ -1,0 +1,1 @@
+# MACE MCP Server - Tools package

--- a/mace-mcp-server/src/tools/coordinate_gen.py
+++ b/mace-mcp-server/src/tools/coordinate_gen.py
@@ -1,0 +1,145 @@
+"""
+SMILES to 3D coordinate file generation.
+
+Uses RDKit for 3D embedding and UFF force-field optimisation, then writes
+the structure to an XYZ file via ASE.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+logger = logging.getLogger("mace_mcp.coordinate_gen")
+
+
+def smiles_to_coordinate_file(
+    smiles: str,
+    output_file: str = "molecule.xyz",
+    random_seed: int = 2025,
+) -> Dict[str, Any]:
+    """Convert a SMILES string to a 3D coordinate file (XYZ format).
+
+    The function generates a 3D molecular structure from a SMILES string
+    using RDKit's distance-geometry embedding and UFF force-field
+    optimisation, then writes the result as an XYZ file via ASE.
+
+    Parameters
+    ----------
+    smiles : str
+        SMILES string representation of the molecule
+        (e.g. ``"CCO"`` for ethanol).
+    output_file : str, optional
+        Path to save the output XYZ coordinate file.  Defaults to
+        ``"molecule.xyz"`` in the current directory.
+    random_seed : int, optional
+        Random seed for RDKit 3D structure generation (default 2025).
+
+    Returns
+    -------
+    dict
+        On success::
+
+            {
+                "status": "completed",
+                "artifact": "coordinate_file",
+                "format": "xyz",
+                "path": "/absolute/path/to/molecule.xyz",
+                "smiles": "CCO",
+                "n_atoms": 9
+            }
+
+        On failure::
+
+            {"status": "failed", "error": "..."}
+    """
+    if not smiles or not smiles.strip():
+        return {"status": "failed", "error": "SMILES string must not be empty."}
+
+    smiles = smiles.strip()
+
+    # --- RDKit imports ---
+    try:
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+    except ImportError:
+        return {
+            "status": "failed",
+            "error": (
+                "RDKit is not installed. Install it with: pip install rdkit-pypi"
+            ),
+        }
+
+    # --- ASE import ---
+    try:
+        from ase import Atoms
+        from ase.io import write as ase_write
+    except ImportError:
+        return {
+            "status": "failed",
+            "error": ("ASE is not installed. Install it with: pip install ase"),
+        }
+
+    # --- Generate 3D structure ---
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return {
+            "status": "failed",
+            "error": f"Invalid SMILES string: '{smiles}'.",
+        }
+
+    # Add explicit hydrogens
+    mol = Chem.AddHs(mol)
+
+    # Embed in 3D
+    embed_result = AllChem.EmbedMolecule(mol, randomSeed=random_seed)
+    if embed_result != 0:
+        return {
+            "status": "failed",
+            "error": (
+                f"Failed to generate 3D coordinates for SMILES '{smiles}'. "
+                "The molecule may be too complex or the SMILES may be invalid."
+            ),
+        }
+
+    # UFF force-field optimisation
+    opt_result = AllChem.UFFOptimizeMolecule(mol)
+    if opt_result != 0:
+        logger.warning(
+            "UFF optimisation did not converge for '%s'; using best geometry obtained.",
+            smiles,
+        )
+
+    # --- Extract atomic data ---
+    conf = mol.GetConformer()
+    numbers = [atom.GetAtomicNum() for atom in mol.GetAtoms()]
+    positions = [list(conf.GetAtomPosition(i)) for i in range(mol.GetNumAtoms())]
+
+    # --- Write XYZ file via ASE ---
+    atoms = Atoms(numbers=numbers, positions=positions)
+
+    try:
+        ase_write(output_file, atoms)
+    except Exception as e:
+        return {
+            "status": "failed",
+            "error": f"Failed to write coordinate file '{output_file}': {e}",
+        }
+
+    abs_path = os.path.abspath(output_file)
+    logger.info(
+        "Generated XYZ file: %s (%d atoms) from SMILES: %s",
+        abs_path,
+        len(numbers),
+        smiles,
+    )
+
+    return {
+        "status": "completed",
+        "artifact": "coordinate_file",
+        "format": "xyz",
+        "path": abs_path,
+        "smiles": smiles,
+        "n_atoms": len(numbers),
+    }

--- a/mace-mcp-server/src/tools/mace_calc.py
+++ b/mace-mcp-server/src/tools/mace_calc.py
@@ -1,0 +1,210 @@
+"""
+MACE machine-learning interatomic potential calculations.
+
+Provides single-point energy evaluation and optional geometry optimisation
+using the MACE foundation model (``mace_mp``) via ASE.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Literal
+
+logger = logging.getLogger("mace_mcp.mace_calc")
+
+
+def run_mace_calculation(
+    input_file: str,
+    mace_model_name: str = "small",
+    device: Literal["cpu", "cuda"] = "cpu",
+    optimize: bool = False,
+    fmax: float = 0.05,
+    max_steps: int = 200,
+) -> Dict[str, Any]:
+    """Run a MACE energy calculation, optionally with geometry optimisation.
+
+    Uses the MACE-MP foundation model to compute the potential energy of
+    a molecular structure.  If ``optimize=True``, a BFGS geometry
+    optimisation is performed before reporting the final energy.
+
+    Parameters
+    ----------
+    input_file : str
+        Path to a structure file readable by ASE (typically ``.xyz``).
+    mace_model_name : str, optional
+        Name of the MACE-MP model to load (default ``"small"``).
+        Common choices: ``"small"``, ``"medium"``, ``"large"``.
+    device : {"cpu", "cuda"}, optional
+        Device to run the calculation on (default ``"cpu"``).
+    optimize : bool, optional
+        If ``True``, run a BFGS geometry optimisation (default ``False``).
+    fmax : float, optional
+        Maximum force convergence criterion in eV/A for optimisation
+        (default 0.05).
+    max_steps : int, optional
+        Maximum number of BFGS optimisation steps (default 200).
+
+    Returns
+    -------
+    dict
+        On success (single-point)::
+
+            {
+                "status": "completed",
+                "mode": "single_point",
+                "input_file": "molecule.xyz",
+                "mace_model": "small",
+                "device": "cpu",
+                "energy_eV": -123.456
+            }
+
+        On success (geometry optimisation)::
+
+            {
+                "status": "completed",
+                "mode": "geometry_optimization",
+                "converged": true,
+                "input_file": "molecule.xyz",
+                "mace_model": "small",
+                "device": "cpu",
+                "energy_eV": -123.789,
+                "final_positions": [[x, y, z], ...],
+                "final_cell": [[ax, ay, az], ...],
+                "fmax": 0.05,
+                "max_steps": 200
+            }
+
+        On failure::
+
+            {"status": "failed", "error": "..."}
+    """
+    # --- Validate input file ---
+    if not input_file or not input_file.strip():
+        return {"status": "failed", "error": "Input file path must not be empty."}
+
+    input_file = input_file.strip()
+
+    if not os.path.isfile(input_file):
+        return {
+            "status": "failed",
+            "error": f"Input structure file '{input_file}' does not exist.",
+        }
+
+    # --- ASE import ---
+    try:
+        from ase.io import read as ase_read
+        from ase.optimize import BFGS
+    except ImportError:
+        return {
+            "status": "failed",
+            "error": "ASE is not installed. Install it with: pip install ase",
+        }
+
+    # --- MACE import ---
+    try:
+        from mace.calculators import mace_mp
+    except ImportError:
+        return {
+            "status": "failed",
+            "error": ("MACE is not installed. Install it with: pip install mace-torch"),
+        }
+
+    # --- Normalise device ---
+    dev = device.lower() if device else "cpu"
+    if dev not in ("cpu", "cuda"):
+        dev = "cpu"
+
+    # --- Read structure ---
+    try:
+        atoms = ase_read(input_file)
+    except Exception as e:
+        return {
+            "status": "failed",
+            "error": f"Could not read '{input_file}' with ASE: {e}",
+        }
+
+    # --- Create MACE calculator ---
+    try:
+        calc = mace_mp(model=mace_model_name, device=dev)
+    except Exception as e:
+        return {
+            "status": "failed",
+            "error": (
+                f"Could not load MACE model '{mace_model_name}'. Original error: {e}"
+            ),
+        }
+
+    atoms.calc = calc
+
+    # --- Single-point calculation ---
+    if not optimize:
+        try:
+            energy = float(atoms.get_potential_energy())
+        except Exception as e:
+            return {
+                "status": "failed",
+                "error": f"MACE single-point calculation failed: {e}",
+            }
+
+        logger.info(
+            "Single-point energy: %.6f eV (file=%s, model=%s, device=%s)",
+            energy,
+            input_file,
+            mace_model_name,
+            dev,
+        )
+
+        return {
+            "status": "completed",
+            "message": "MACE single-point energy computed.",
+            "mode": "single_point",
+            "input_file": input_file,
+            "mace_model": mace_model_name,
+            "device": dev,
+            "energy_eV": energy,
+        }
+
+    # --- Geometry optimisation ---
+    try:
+        opt = BFGS(atoms)
+        opt.run(fmax=fmax, steps=max_steps)
+        converged = True
+    except Exception as e:
+        return {
+            "status": "failed",
+            "error": f"Geometry optimisation failed: {e}",
+        }
+
+    try:
+        final_energy = float(atoms.get_potential_energy())
+    except Exception as e:
+        return {
+            "status": "failed",
+            "error": f"Could not retrieve energy after optimisation: {e}",
+        }
+
+    logger.info(
+        "Geometry optimisation completed: %.6f eV "
+        "(converged=%s, file=%s, model=%s, device=%s)",
+        final_energy,
+        converged,
+        input_file,
+        mace_model_name,
+        dev,
+    )
+
+    return {
+        "status": "completed",
+        "message": "MACE geometry optimisation completed.",
+        "mode": "geometry_optimization",
+        "converged": converged,
+        "input_file": input_file,
+        "mace_model": mace_model_name,
+        "device": dev,
+        "energy_eV": final_energy,
+        "final_positions": atoms.get_positions().tolist(),
+        "final_cell": atoms.get_cell().tolist(),
+        "fmax": fmax,
+        "max_steps": max_steps,
+    }

--- a/mace-mcp-server/src/tools/molecule_lookup.py
+++ b/mace-mcp-server/src/tools/molecule_lookup.py
@@ -1,0 +1,79 @@
+"""
+Molecule name to SMILES lookup via PubChem.
+
+Wraps PubChemPy to resolve a human-readable molecule name (e.g. "aspirin",
+"ethanol") into its canonical SMILES representation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger("mace_mcp.molecule_lookup")
+
+
+def molecule_name_to_smiles(name: str) -> Dict[str, Any]:
+    """Convert a molecule name to its canonical SMILES string via PubChem.
+
+    Parameters
+    ----------
+    name : str
+        The common or IUPAC name of the molecule (e.g. "aspirin", "water",
+        "ethanol").
+
+    Returns
+    -------
+    dict
+        On success::
+
+            {
+                "status": "completed",
+                "molecule_name": "aspirin",
+                "smiles": "CC(=O)OC1=CC=CC=C1C(=O)O"
+            }
+
+        On failure::
+
+            {"status": "failed", "error": "..."}
+    """
+    if not name or not name.strip():
+        return {"status": "failed", "error": "Molecule name must not be empty."}
+
+    name = name.strip()
+
+    try:
+        import pubchempy
+    except ImportError:
+        return {
+            "status": "failed",
+            "error": (
+                "pubchempy is not installed. Install it with: pip install pubchempy"
+            ),
+        }
+
+    try:
+        compounds = pubchempy.get_compounds(str(name), "name")
+    except Exception as e:
+        return {
+            "status": "failed",
+            "error": f"PubChem lookup failed for '{name}': {e}",
+        }
+
+    if not compounds:
+        return {
+            "status": "failed",
+            "error": (
+                f"No compounds found in PubChem for '{name}'. "
+                "Check the spelling or try a different name."
+            ),
+        }
+
+    smiles = compounds[0].canonical_smiles
+    logger.info("Resolved '%s' -> SMILES: %s", name, smiles)
+
+    return {
+        "status": "completed",
+        "molecule_name": name,
+        "smiles": smiles,
+    }

--- a/mace-mcp-server/tests/check_env.py
+++ b/mace-mcp-server/tests/check_env.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Environment check for the MACE MCP Server.
+
+Verifies that all required Python dependencies are importable and prints
+a summary.  Run this after installing requirements to confirm your
+environment is set up correctly:
+
+    python tests/check_env.py
+
+Exit code 0 means all checks passed; non-zero means one or more failed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+# ---------------------------------------------------------------------------
+# ANSI colour helpers (disabled when output is not a terminal)
+# ---------------------------------------------------------------------------
+
+_USE_COLOR = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def _green(text: str) -> str:
+    return f"\033[32m{text}\033[0m" if _USE_COLOR else text
+
+
+def _red(text: str) -> str:
+    return f"\033[31m{text}\033[0m" if _USE_COLOR else text
+
+
+def _bold(text: str) -> str:
+    return f"\033[1m{text}\033[0m" if _USE_COLOR else text
+
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+
+# Each entry: (human-readable name, import statement to exec, install hint)
+CHECKS: list[tuple[str, str, str]] = [
+    (
+        "MCP SDK",
+        "from mcp.server.fastmcp import FastMCP",
+        "pip install 'mcp>=1.0.0'",
+    ),
+    (
+        "PubChemPy",
+        "import pubchempy",
+        "pip install pubchempy",
+    ),
+    (
+        "RDKit",
+        "from rdkit import Chem",
+        "pip install rdkit   # or: conda install -c conda-forge rdkit",
+    ),
+    (
+        "ASE",
+        "import ase",
+        "pip install 'ase>=3.22.0'",
+    ),
+    (
+        "MACE",
+        "from mace.calculators import mace_mp",
+        "pip install mace-torch   # requires PyTorch",
+    ),
+]
+
+
+def run_checks() -> bool:
+    """Run all dependency checks.  Returns True if every check passed."""
+    print(_bold("MACE MCP Server — environment check"))
+    print("=" * 44)
+    print()
+
+    passed = 0
+    failed = 0
+    failures: list[tuple[str, str]] = []
+
+    for name, import_stmt, hint in CHECKS:
+        try:
+            exec(import_stmt)  # noqa: S102
+            print(f"  {_green('OK')}   {name}")
+            passed += 1
+        except Exception as exc:
+            print(f"  {_red('FAIL')} {name}  ({exc})")
+            failures.append((name, hint))
+            failed += 1
+
+    # Summary
+    print()
+    print("-" * 44)
+    total = passed + failed
+
+    if failed == 0:
+        print(_green(f"All {total} checks passed.  Environment is ready."))
+    else:
+        print(
+            _red(f"{failed} of {total} check(s) failed.")
+            + "  Review the setup instructions in README.md."
+        )
+        print()
+        print("To fix the failing dependencies:")
+        for name, hint in failures:
+            print(f"  {name}: {hint}")
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = run_checks()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
# Description:
## Summary
- Add a new mace-mcp-server directory containing an MCP (Model Context Protocol) server that exposes MACE machine-learning interatomic potential calculations as tools
- Include three chemistry tools: molecule name lookup via PubChem, SMILES-to-3D coordinate generation (RDKit + ASE), and MACE-MP energy calculations with optional geometry optimization. Tools adopted from https://github.com/argonne-lcf/ChemGraph.
- Add OpenCode configuration for both ALCF inference service and the MCP server itself, so users can interact with the chemistry tools through OpenCode's chat interface without writing any orchestration code.

## Details
This PR introduces a complete MCP server (mace-mcp-server/) that enables any MCP-compatible AI client to run molecular energy calculations. The server exposes three tools:
1. molecule_name_to_smiles -- Resolves common molecule names (e.g. "aspirin", "ethanol") to canonical SMILES strings via PubChem
2. smiles_to_coordinate_file -- Generates 3D molecular structures from SMILES using RDKit's distance-geometry embedding and UFF force-field optimization, outputting XYZ files via ASE
3. run_mace_calculation -- Computes potential energies using the MACE-MP foundation model, with optional BFGS geometry optimization.